### PR TITLE
Leave HTML and Body tags in CSS.

### DIFF
--- a/purgecss.config.js
+++ b/purgecss.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   content: ['./public/**/*.html', './src/**/*.js'],
   css: ['./src/layouts/index.css'],
+  whitelist: ['body', 'html'],
   extractors: [
     {
       extractor: class {


### PR DESCRIPTION
This will leave css for html and body tag. This is needed since these tags are not present in gatsbyjs src folder