### PR TITLE
Update regex in purgecss config

### DIFF
--- a/purgecss.config.js
+++ b/purgecss.config.js
@@ -6,7 +6,7 @@ module.exports = {
     {
       extractor: class {
         static extract(content) {
-          return content.match(/[A-z0-9-:\/]+/g)
+          return content.match(/[A-z0-9-:/]+/g)
         }
       },
       extensions: ['html', 'js'],


### PR DESCRIPTION
I use eslint in my project and this extra character was noticed by the linter.

`\/` is not escaping `/` but is just saying to look for a literal `/`. However, since it's one of the things being matched already, there's no need to call it out as a literal match. It will get matched anyway.