### PR TITLE
Let purgecss respect ignore comment in style.css

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,5 +1,5 @@
-/* purgecss start ignore */
+/*! purgecss start ignore */
 @tailwind base;
 @tailwind components;
-/* purgecss end ignore */
+/*! purgecss end ignore */
 @tailwind utilities;


### PR DESCRIPTION
Currently purgecss does not respect the start/end ignore comment in style.css, because these get removed by cssnano. 
[Tailwind](https://tailwindcss.com/docs/controlling-file-size/#setting-up-purgecss) does recommend putting these ignore comments there, so this PR makes sure they are respected by making them [special comments](https://github.com/FullHuman/purgecss/issues/90#issuecomment-559647253). 