### PR TITLE
Use Autoprefixer in development and other minor fixes

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -28,7 +28,7 @@ module.exports = {
       resolve: "gatsby-plugin-postcss",
       options: {
         postCssPlugins: [
-          require(`tailwindcss`)(`./tailwind.config.js`),
+          require(`tailwindcss`)(tailwindConfig),
           require(`autoprefixer`),
           ...(process.env.NODE_ENV === "production"
             ? [require(`cssnano`)]

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,3 +1,8 @@
+const resolveConfig = require("tailwindcss/resolveConfig");
+const tailwindConfig = require("./tailwind.config.js");
+
+const fullConfig = resolveConfig(tailwindConfig);
+
 module.exports = {
   siteMetadata: {
     title: `Gatsby Starter Tailwind`,
@@ -13,8 +18,8 @@ module.exports = {
         name: `gatsby-starter-tailwind`,
         short_name: `starter`,
         start_url: `/`,
-        background_color: `#ffffff`,
-        theme_color: `#4dc0b5`,
+        background_color: fullConfig.theme.colors.white,
+        theme_color: fullConfig.theme.colors.teal["400"],
         display: `minimal-ui`,
         icon: `src/images/tailwind-icon.png`,
       },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -25,12 +25,12 @@ module.exports = {
       },
     },
     {
-      resolve: "gatsby-plugin-postcss",
+      resolve: `gatsby-plugin-postcss`,
       options: {
         postCssPlugins: [
           require(`tailwindcss`)(tailwindConfig),
           require(`autoprefixer`),
-          ...(process.env.NODE_ENV === "production"
+          ...(process.env.NODE_ENV === `production`
             ? [require(`cssnano`)]
             : []),
         ],

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -24,8 +24,9 @@ module.exports = {
       options: {
         postCssPlugins: [
           require(`tailwindcss`)(`./tailwind.config.js`),
+          require(`autoprefixer`),
           ...(process.env.NODE_ENV === "production"
-            ? [require(`autoprefixer`), require(`cssnano`)]
+            ? [require(`cssnano`)]
             : []),
         ],
       },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,7 +5,7 @@ module.exports = {
     author: `@taylorbryant`,
   },
   plugins: [
-    "gatsby-plugin-eslint",
+    `gatsby-plugin-eslint`,
     `gatsby-plugin-react-helmet`,
     {
       resolve: `gatsby-plugin-manifest`,


### PR DESCRIPTION
I was working on a site based off this starter and couldn't work out why the custom `<select>` element (which I was styling with the [`@tailwindcss/custom-forms`](https://github.com/tailwindcss/custom-forms) plugin) wasn't getting the custom styles I was using.

I realised that it was because [`appearance: none;` needs to be vendor prefixed to work](https://caniuse.com/#feat=css-appearance).

As such, I think it makes sense to use Autoprefixer during development.

I also noticed that the colour which was being used in the manifest doesn't exist in the default Tailwind colour palette (probably from pre: Tailwind 1.0) so I added support for getting the colour from Tailwind directly.