### PR TITLE
Use PurgeCSS built into Tailwind 1.4

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -36,13 +36,6 @@ module.exports = {
         ],
       },
     },
-    {
-      resolve: `gatsby-plugin-purgecss`,
-      options: {
-        tailwind: true,
-        purgeOnly: [`src/css/style.css`],
-      },
-    },
     `gatsby-plugin-offline`,
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1405,6 +1405,73 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@fullhuman/postcss-purgecss": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-2.1.2.tgz",
+      "integrity": "sha512-Jf34YVBK9GtXTblpu0svNUJdA7rTQoRMz+yEJe6mwTnXDIGipWLzaX/VgU/x6IPC6WvU5SY/XlawwqhxoyFPTg==",
+      "dev": true,
+      "requires": {
+        "postcss": "7.0.27",
+        "purgecss": "^2.1.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.27",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+          "integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "postcss-selector-parser": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+          "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+          "dev": true,
+          "requires": {
+            "cssesc": "^3.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        },
+        "purgecss": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-2.1.2.tgz",
+          "integrity": "sha512-5oDBxiT9VonwKmEMohPFRFZrj8fdSVKxHPwq7G5Rx/2pXicZFJu+D4m5bb3NuV0sSK3ooNxq5jFIwwHzifP5FA==",
+          "dev": true,
+          "requires": {
+            "commander": "^5.0.0",
+            "glob": "^7.0.0",
+            "postcss": "7.0.27",
+            "postcss-selector-parser": "^6.0.2"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "@hapi/address": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
@@ -3690,11 +3757,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "atob": {
       "version": "2.1.2",
@@ -10206,63 +10268,6 @@
         }
       }
     },
-    "gatsby-plugin-purgecss": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-purgecss/-/gatsby-plugin-purgecss-5.0.0.tgz",
-      "integrity": "sha512-vzBQSBfZuzmm6+P5qedw+LCgtQm0HRzdDUjytdCwgYCBRuxUjxSkHAFBpemSXqkklfWxs6jcLjRuElVqSDLT1w==",
-      "requires": {
-        "fs-extra": "^9.0.0",
-        "loader-utils": "^2.0.0",
-        "purgecss": "^2.1.0"
-      },
-      "dependencies": {
-        "emojis-list": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
-        },
-        "fs-extra": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-          "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
-        },
-        "jsonfile": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^1.0.0"
-          }
-        },
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
-        "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
-        }
-      }
-    },
     "gatsby-plugin-react-helmet": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.3.0.tgz",
@@ -16537,57 +16542,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
-    "purgecss": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-2.1.0.tgz",
-      "integrity": "sha512-QnXhowNjeWo9vNnGES2LVzDXdRR/8EvG/O03m4bYOWfAX0ShmG/Pmj7brVtVBy2eaaRAmNy23L+GBc4SpDFUeQ==",
-      "requires": {
-        "commander": "^4.0.0",
-        "glob": "^7.0.0",
-        "postcss": "7.0.27",
-        "postcss-selector-parser": "^6.0.2"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
-        },
-        "postcss": {
-          "version": "7.0.27",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
-          "integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "postcss-selector-parser": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
-          "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
-          "requires": {
-            "cssesc": "^3.0.0",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -19245,14 +19199,17 @@
       }
     },
     "tailwindcss": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.3.5.tgz",
-      "integrity": "sha512-hHGShfHBj7tAQRobnsYckDySPpMDnPF4KejHYYRcZjZQvyRRnCSHi2S905icK24HrYadOq9pZKwENqg2axSviw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.4.0.tgz",
+      "integrity": "sha512-Np/VKalw2CI8EUSKNwGLFoqWIiBYVv5LpzBjQKI8XajA2SaVDj/C+YKHctmSZKR97LiiB1S81itZwtGT+BQAiQ==",
       "dev": true,
       "requires": {
+        "@fullhuman/postcss-purgecss": "^2.1.2",
         "autoprefixer": "^9.4.5",
+        "browserslist": "^4.12.0",
         "bytes": "^3.0.0",
         "chalk": "^4.0.0",
+        "color": "^3.1.2",
         "detective": "^5.2.0",
         "fs-extra": "^8.0.0",
         "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "gatsby-plugin-manifest": "2.4.1",
     "gatsby-plugin-offline": "3.2.0",
     "gatsby-plugin-postcss": "2.3.0",
-    "gatsby-plugin-purgecss": "5.0.0",
     "gatsby-plugin-react-helmet": "3.3.0",
     "gatsby-plugin-sharp": "2.6.0",
     "prop-types": "15.7.2",
@@ -49,7 +48,7 @@
     "eslint-plugin-react": "7.19.0",
     "gatsby-plugin-eslint": "2.0.8",
     "prettier": "2.0.5",
-    "tailwindcss": "1.3.5"
+    "tailwindcss": "^1.4.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-react": "7.19.0",
     "gatsby-plugin-eslint": "2.0.8",
     "prettier": "2.0.5",
-    "tailwindcss": "^1.4.0"
+    "tailwindcss": "1.4.0"
   },
   "repository": {
     "type": "git",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,8 @@
 // See https://tailwindcss.com/docs/configuration for details
 module.exports = {
+  purge: [
+    './src/**/*.js',
+  ],
   theme: {},
   variants: {},
   // https://github.com/tailwindcss/custom-forms


### PR DESCRIPTION
The latest release of Tailwind has PurgeCSS built in, so we can drop the `gatsby-plugin-purgecss` dependancy, remove it from the `gatsby-config.js` file, and instead configure it inside of `tailwind.config.js`.