### PR TITLE
Roll back to an older version of Gatsby

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2298,9 +2298,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.0.tgz",
-          "integrity": "sha512-dVQHhuh/W6KlmSOQZliHH7ba41dsCOhqPwkeW6dwOjy0FqSx/hGihKZyABDmjNkDbowr2141aAIJYfj2XdoX8Q==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.3.tgz",
+          "integrity": "sha512-9MvSKeo+8DM72706FvrUP8figQjRzSwBswWrXviyWyt3wSkk6MU2cURQKfMpc0I6nswZvkDSqYoQQ/6mazoXxA==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -2329,9 +2329,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.0.tgz",
-          "integrity": "sha512-dVQHhuh/W6KlmSOQZliHH7ba41dsCOhqPwkeW6dwOjy0FqSx/hGihKZyABDmjNkDbowr2141aAIJYfj2XdoX8Q==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.3.tgz",
+          "integrity": "sha512-9MvSKeo+8DM72706FvrUP8figQjRzSwBswWrXviyWyt3wSkk6MU2cURQKfMpc0I6nswZvkDSqYoQQ/6mazoXxA==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -2356,9 +2356,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.0.tgz",
-          "integrity": "sha512-dVQHhuh/W6KlmSOQZliHH7ba41dsCOhqPwkeW6dwOjy0FqSx/hGihKZyABDmjNkDbowr2141aAIJYfj2XdoX8Q==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.3.tgz",
+          "integrity": "sha512-9MvSKeo+8DM72706FvrUP8figQjRzSwBswWrXviyWyt3wSkk6MU2cURQKfMpc0I6nswZvkDSqYoQQ/6mazoXxA==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -2403,9 +2403,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.0.tgz",
-          "integrity": "sha512-dVQHhuh/W6KlmSOQZliHH7ba41dsCOhqPwkeW6dwOjy0FqSx/hGihKZyABDmjNkDbowr2141aAIJYfj2XdoX8Q==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.3.tgz",
+          "integrity": "sha512-9MvSKeo+8DM72706FvrUP8figQjRzSwBswWrXviyWyt3wSkk6MU2cURQKfMpc0I6nswZvkDSqYoQQ/6mazoXxA==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -2436,9 +2436,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.0.tgz",
-          "integrity": "sha512-dVQHhuh/W6KlmSOQZliHH7ba41dsCOhqPwkeW6dwOjy0FqSx/hGihKZyABDmjNkDbowr2141aAIJYfj2XdoX8Q==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.3.tgz",
+          "integrity": "sha512-9MvSKeo+8DM72706FvrUP8figQjRzSwBswWrXviyWyt3wSkk6MU2cURQKfMpc0I6nswZvkDSqYoQQ/6mazoXxA==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -2494,9 +2494,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.0.tgz",
-          "integrity": "sha512-dVQHhuh/W6KlmSOQZliHH7ba41dsCOhqPwkeW6dwOjy0FqSx/hGihKZyABDmjNkDbowr2141aAIJYfj2XdoX8Q==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.3.tgz",
+          "integrity": "sha512-9MvSKeo+8DM72706FvrUP8figQjRzSwBswWrXviyWyt3wSkk6MU2cURQKfMpc0I6nswZvkDSqYoQQ/6mazoXxA==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -2520,9 +2520,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.0.tgz",
-          "integrity": "sha512-dVQHhuh/W6KlmSOQZliHH7ba41dsCOhqPwkeW6dwOjy0FqSx/hGihKZyABDmjNkDbowr2141aAIJYfj2XdoX8Q==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.3.tgz",
+          "integrity": "sha512-9MvSKeo+8DM72706FvrUP8figQjRzSwBswWrXviyWyt3wSkk6MU2cURQKfMpc0I6nswZvkDSqYoQQ/6mazoXxA==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -2561,9 +2561,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.0.tgz",
-          "integrity": "sha512-dVQHhuh/W6KlmSOQZliHH7ba41dsCOhqPwkeW6dwOjy0FqSx/hGihKZyABDmjNkDbowr2141aAIJYfj2XdoX8Q==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.3.tgz",
+          "integrity": "sha512-9MvSKeo+8DM72706FvrUP8figQjRzSwBswWrXviyWyt3wSkk6MU2cURQKfMpc0I6nswZvkDSqYoQQ/6mazoXxA==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -2611,21 +2611,21 @@
       }
     },
     "@graphql-tools/wrap": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-7.0.4.tgz",
-      "integrity": "sha512-txBs0W4k3WR86aEzBYXtKdGeeUXCNdRNxjQA/95T6ywNYoM8pw2mvpoXrWOvzbeaH3zwhbHY7kwii4atrC9irg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-7.0.5.tgz",
+      "integrity": "sha512-KCWBXsDfvG46GNUawRltJL4j9BMGoOG7oo3WEyCQP+SByWXiTe5cBF45SLDVQgdjljGNZhZ4Lq/7avIkF7/zDQ==",
       "requires": {
         "@graphql-tools/delegate": "^7.0.7",
         "@graphql-tools/schema": "^7.1.2",
-        "@graphql-tools/utils": "^7.1.4",
+        "@graphql-tools/utils": "^7.2.1",
         "is-promise": "4.0.0",
         "tslib": "~2.0.1"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.0.tgz",
-          "integrity": "sha512-dVQHhuh/W6KlmSOQZliHH7ba41dsCOhqPwkeW6dwOjy0FqSx/hGihKZyABDmjNkDbowr2141aAIJYfj2XdoX8Q==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.3.tgz",
+          "integrity": "sha512-9MvSKeo+8DM72706FvrUP8figQjRzSwBswWrXviyWyt3wSkk6MU2cURQKfMpc0I6nswZvkDSqYoQQ/6mazoXxA==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -3346,9 +3346,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.166",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.166.tgz",
-      "integrity": "sha512-A3YT/c1oTlyvvW/GQqG86EyqWNrT/tisOIh2mW3YCgcx71TNjiTZA3zYZWA5BCmtsOTXjhliy4c4yEkErw6njA=="
+      "version": "4.14.167",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.167.tgz",
+      "integrity": "sha512-w7tQPjARrvdeBkX/Rwg95S592JwxqOjmms3zWQ0XZgSyxSLdzWaYH3vErBhdVS/lRBX7F8aBYcYJYTr5TMGOzw=="
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -3805,11 +3805,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
-    },
-    "anser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/anser/-/anser-2.0.1.tgz",
-      "integrity": "sha512-4g5Np4CVD3c5c/36Mj0jllEA5bQcuXF0dqakZcuHGeubBzw93EAhwRuQCzgFm4/ZwvyBMzFdtn9BcihOjnxIdQ=="
     },
     "ansi-align": {
       "version": "3.0.0",
@@ -4679,40 +4674,24 @@
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
     },
     "babel-preset-gatsby": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.9.1.tgz",
-      "integrity": "sha512-J/2e5qn6G0Sn1YF1MGOMfYJrgaKAEUXbr52v06Y24buHdj52HUcftF8/xspSpBADLP/0MHt053AHFOOJvA9BzA==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.5.16.tgz",
+      "integrity": "sha512-zcUYvHRnDxwQmzJnkWtHk4x7cGaMbQjTJIKrvCWpS9u10hQOQUNAz/ZKSH1vUmB4oYap6m+sHDoDIr7PNoCAEQ==",
       "requires": {
-        "@babel/plugin-proposal-class-properties": "^7.12.1",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
-        "@babel/plugin-proposal-optional-chaining": "^7.12.1",
+        "@babel/plugin-proposal-class-properties": "^7.10.4",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
+        "@babel/plugin-proposal-optional-chaining": "^7.11.0",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.12.1",
-        "@babel/plugin-transform-spread": "^7.12.1",
-        "@babel/preset-env": "^7.12.1",
-        "@babel/preset-react": "^7.12.5",
-        "@babel/runtime": "^7.12.5",
+        "@babel/plugin-transform-runtime": "^7.11.5",
+        "@babel/plugin-transform-spread": "^7.11.0",
+        "@babel/preset-env": "^7.11.5",
+        "@babel/preset-react": "^7.10.4",
+        "@babel/runtime": "^7.11.2",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "babel-plugin-macros": "^2.8.0",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-        "gatsby-core-utils": "^1.7.1",
-        "gatsby-legacy-polyfills": "^0.4.0"
-      },
-      "dependencies": {
-        "gatsby-core-utils": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.7.1.tgz",
-          "integrity": "sha512-hnzQCixp2C4opmSgjido/CQwSt4FL3CcmGwq6fK3PVPTT3hLPz7rvuTMQIUlR8BJjGYai6i5f6V3wfkCJ3VTgQ==",
-          "requires": {
-            "ci-info": "2.0.0",
-            "configstore": "^5.0.1",
-            "fs-extra": "^8.1.0",
-            "node-object-hash": "^2.0.0",
-            "proper-lockfile": "^4.1.1",
-            "tmp": "^0.2.1",
-            "xdg-basedir": "^4.0.0"
-          }
-        }
+        "gatsby-core-utils": "^1.3.24",
+        "gatsby-legacy-polyfills": "^0.0.6"
       }
     },
     "babel-runtime": {
@@ -5699,6 +5678,14 @@
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         }
+      }
+    },
+    "cache-manager-fs-hash": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/cache-manager-fs-hash/-/cache-manager-fs-hash-0.0.9.tgz",
+      "integrity": "sha512-G0RUUSMZADiMx/0tHjPa+uzJyjtVB/Xt9yuFm6g/rBpm0p/IMr4atUWX2G2f1yGCPmDnyUcFz4RlSpgNRgvldg==",
+      "requires": {
+        "lockfile": "^1.0.4"
       }
     },
     "cacheable-lookup": {
@@ -6969,14 +6956,14 @@
       }
     },
     "css-select": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
+      "integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
       "requires": {
-        "boolbase": "~1.0.0",
-        "css-what": "2.1",
-        "domutils": "1.5.1",
-        "nth-check": "~1.0.1"
+        "boolbase": "^1.0.0",
+        "css-what": "^3.2.1",
+        "domutils": "^1.7.0",
+        "nth-check": "^1.0.2"
       }
     },
     "css-select-base-adapter": {
@@ -7015,9 +7002,9 @@
       "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY="
     },
     "css-what": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
-      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
+      "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ=="
     },
     "cssesc": {
       "version": "3.0.0",
@@ -7820,9 +7807,9 @@
       }
     },
     "domutils": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
@@ -10034,16 +10021,16 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gatsby": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.29.2.tgz",
-      "integrity": "sha512-89My5UzWA3Ix6zVWr2qQ95nIfVGBRRTpJ5gvp9oqAS+pwV6WxUg/vn7TDVifyg1eqS1jS+FDX96+txji+54QPg==",
+      "version": "2.25.1",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.25.1.tgz",
+      "integrity": "sha512-2MLGL0MooLGmGQhSjIjq+mH95lE3PbrtZ8xgcmN1JOsjR/dJ+Fx/BoZC3CdqPku/zflMNlCb99vuB2HQaXiRdg==",
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.12.5",
-        "@babel/runtime": "^7.12.5",
-        "@babel/traverse": "^7.12.5",
-        "@babel/types": "^7.12.6",
+        "@babel/core": "^7.11.6",
+        "@babel/parser": "^7.11.5",
+        "@babel/runtime": "^7.11.2",
+        "@babel/traverse": "^7.11.5",
+        "@babel/types": "^7.11.5",
         "@hapi/joi": "^15.1.1",
         "@mikaelkristiansson/domready": "^1.0.10",
         "@nodelib/fs.walk": "^1.2.4",
@@ -10054,8 +10041,6 @@
         "@typescript-eslint/eslint-plugin": "^2.24.0",
         "@typescript-eslint/parser": "^2.24.0",
         "address": "1.1.2",
-        "anser": "^2.0.1",
-        "ansi-html": "^0.0.7",
         "autoprefixer": "^9.8.4",
         "axios": "^0.20.0",
         "babel-core": "7.0.0-bridge.0",
@@ -10064,15 +10049,16 @@
         "babel-plugin-add-module-exports": "^0.3.3",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "babel-plugin-lodash": "3.3.4",
-        "babel-plugin-remove-graphql-queries": "^2.13.0",
-        "babel-preset-gatsby": "^0.9.1",
+        "babel-plugin-remove-graphql-queries": "^2.9.20",
+        "babel-preset-gatsby": "^0.5.15",
         "better-opn": "^2.0.0",
         "better-queue": "^3.8.10",
         "bluebird": "^3.7.2",
         "body-parser": "^1.19.0",
         "browserslist": "^4.12.2",
         "cache-manager": "^2.11.1",
-        "chalk": "^4.1.0",
+        "cache-manager-fs-hash": "^0.0.9",
+        "chalk": "^2.4.2",
         "chokidar": "^3.4.2",
         "common-tags": "^1.8.0",
         "compression": "^1.7.4",
@@ -10105,16 +10091,16 @@
         "find-cache-dir": "^3.3.1",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^8.1.0",
-        "gatsby-cli": "^2.16.2",
-        "gatsby-core-utils": "^1.7.1",
-        "gatsby-graphiql-explorer": "^0.8.0",
-        "gatsby-legacy-polyfills": "^0.4.0",
-        "gatsby-link": "^2.8.0",
-        "gatsby-plugin-page-creator": "^2.7.2",
-        "gatsby-plugin-typescript": "^2.9.0",
-        "gatsby-plugin-utils": "^0.6.0",
-        "gatsby-react-router-scroll": "^3.4.0",
-        "gatsby-telemetry": "^1.7.1",
+        "gatsby-cli": "^2.12.115",
+        "gatsby-core-utils": "^1.3.23",
+        "gatsby-graphiql-explorer": "^0.4.15",
+        "gatsby-legacy-polyfills": "^0.0.6",
+        "gatsby-link": "^2.4.16",
+        "gatsby-plugin-page-creator": "^2.3.34",
+        "gatsby-plugin-typescript": "^2.5.0",
+        "gatsby-plugin-utils": "^0.2.40",
+        "gatsby-react-router-scroll": "^3.0.15",
+        "gatsby-telemetry": "^1.3.39",
         "glob": "^7.1.6",
         "got": "8.3.2",
         "graphql": "^14.6.0",
@@ -10155,7 +10141,7 @@
         "query-string": "^6.13.1",
         "raw-loader": "^0.5.1",
         "react-dev-utils": "^4.2.3",
-        "react-error-overlay": "^3.0.0",
+        "react-error-overlay": "^6.0.7",
         "react-hot-loader": "^4.12.21",
         "react-refresh": "^0.8.3",
         "redux": "^4.0.5",
@@ -10166,14 +10152,10 @@
         "slugify": "^1.4.4",
         "socket.io": "^2.3.0",
         "socket.io-client": "2.3.0",
-        "source-map": "^0.7.3",
-        "source-map-support": "^0.5.19",
         "st": "^2.0.0",
         "stack-trace": "^0.0.10",
         "string-similarity": "^1.2.2",
-        "strip-ansi": "^5.2.0",
         "style-loader": "^0.23.1",
-        "terminal-link": "^2.1.1",
         "terser-webpack-plugin": "^2.3.8",
         "tmp": "^0.2.1",
         "true-case-path": "^2.2.1",
@@ -10209,13 +10191,6 @@
             "@babel/types": "^7.12.11",
             "jsesc": "^2.5.1",
             "source-map": "^0.5.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-            }
           }
         },
         "@babel/helper-function-name": {
@@ -10252,18 +10227,6 @@
             "@babel/helper-validator-identifier": "^7.10.4",
             "chalk": "^2.0.0",
             "js-tokens": "^4.0.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            }
           }
         },
         "@babel/parser": {
@@ -10329,6 +10292,14 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
         "autoprefixer": {
           "version": "9.8.6",
           "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
@@ -10344,41 +10315,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001170",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001170.tgz",
-          "integrity": "sha512-Dd4d/+0tsK0UNLrZs3CvNukqalnVTRrxb5mcQm8rHL49t7V5ZaTygwXkrq+FB+dVDf++4ri8eJnFEJAB8332PA=="
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
-            },
-            "has-flag": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-            },
-            "supports-color": {
-              "version": "7.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            }
-          }
+          "version": "1.0.30001171",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001171.tgz",
+          "integrity": "sha512-5Alrh8TTYPG9IH4UkRqEBZoEToWRLvPbSQokvzSz0lii8/FOWKG4keO1HoYfPWs8IF/NH/dyNPg1cmJGvV3Zlg=="
         },
         "cliui": {
           "version": "6.0.0",
@@ -10495,16 +10434,6 @@
             "v8-compile-cache": "^2.0.3"
           },
           "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            },
             "debug": {
               "version": "4.3.1",
               "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -10617,6 +10546,15 @@
             "yurnalist": "^1.1.2"
           },
           "dependencies": {
+            "chalk": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+              "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            },
             "cross-spawn": {
               "version": "7.0.3",
               "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -10643,42 +10581,60 @@
                 "signal-exit": "^3.0.2",
                 "strip-final-newline": "^2.0.0"
               }
+            },
+            "gatsby-core-utils": {
+              "version": "1.7.1",
+              "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.7.1.tgz",
+              "integrity": "sha512-hnzQCixp2C4opmSgjido/CQwSt4FL3CcmGwq6fK3PVPTT3hLPz7rvuTMQIUlR8BJjGYai6i5f6V3wfkCJ3VTgQ==",
+              "requires": {
+                "ci-info": "2.0.0",
+                "configstore": "^5.0.1",
+                "fs-extra": "^8.1.0",
+                "node-object-hash": "^2.0.0",
+                "proper-lockfile": "^4.1.1",
+                "tmp": "^0.2.1",
+                "xdg-basedir": "^4.0.0"
+              }
+            },
+            "gatsby-telemetry": {
+              "version": "1.7.1",
+              "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.7.1.tgz",
+              "integrity": "sha512-kLIjpspvnoCD7+5ybAv5uc/zc4NK8EMwlKEBHPxx7RJBEK220deD1ixtNEcO7nsDwH0Y+eE8Yom8qOPbr0F6Mw==",
+              "requires": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/runtime": "^7.12.5",
+                "@turist/fetch": "^7.1.7",
+                "@turist/time": "^0.0.1",
+                "async-retry-ng": "^2.0.1",
+                "boxen": "^4.2.0",
+                "configstore": "^5.0.1",
+                "fs-extra": "^8.1.0",
+                "gatsby-core-utils": "^1.7.1",
+                "git-up": "^4.0.2",
+                "is-docker": "^2.1.1",
+                "lodash": "^4.17.20",
+                "node-fetch": "^2.6.1",
+                "uuid": "3.4.0"
+              }
+            },
+            "has-flag": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+            },
+            "source-map": {
+              "version": "0.7.3",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+              "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+            },
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
             }
-          }
-        },
-        "gatsby-core-utils": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.7.1.tgz",
-          "integrity": "sha512-hnzQCixp2C4opmSgjido/CQwSt4FL3CcmGwq6fK3PVPTT3hLPz7rvuTMQIUlR8BJjGYai6i5f6V3wfkCJ3VTgQ==",
-          "requires": {
-            "ci-info": "2.0.0",
-            "configstore": "^5.0.1",
-            "fs-extra": "^8.1.0",
-            "node-object-hash": "^2.0.0",
-            "proper-lockfile": "^4.1.1",
-            "tmp": "^0.2.1",
-            "xdg-basedir": "^4.0.0"
-          }
-        },
-        "gatsby-telemetry": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.7.1.tgz",
-          "integrity": "sha512-kLIjpspvnoCD7+5ybAv5uc/zc4NK8EMwlKEBHPxx7RJBEK220deD1ixtNEcO7nsDwH0Y+eE8Yom8qOPbr0F6Mw==",
-          "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/runtime": "^7.12.5",
-            "@turist/fetch": "^7.1.7",
-            "@turist/time": "^0.0.1",
-            "async-retry-ng": "^2.0.1",
-            "boxen": "^4.2.0",
-            "configstore": "^5.0.1",
-            "fs-extra": "^8.1.0",
-            "gatsby-core-utils": "^1.7.1",
-            "git-up": "^4.0.2",
-            "is-docker": "^2.1.1",
-            "lodash": "^4.17.20",
-            "node-fetch": "^2.6.1",
-            "uuid": "3.4.0"
           }
         },
         "glob": {
@@ -10885,38 +10841,10 @@
             "supports-color": "^6.1.0"
           },
           "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "5.5.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                  "requires": {
-                    "has-flag": "^3.0.0"
-                  }
-                }
-              }
-            },
             "source-map": {
               "version": "0.6.1",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
               "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-            },
-            "supports-color": {
-              "version": "6.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
             }
           }
         },
@@ -10969,11 +10897,6 @@
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
         },
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
-        },
         "string-width": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -11005,6 +10928,14 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
             "ansi-regex": "^4.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "requires": {
+            "has-flag": "^3.0.0"
           }
         },
         "type-check": {
@@ -11048,14 +10979,6 @@
               "version": "5.0.0",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
               "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-            },
-            "ansi-styles": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
             },
             "strip-ansi": {
               "version": "6.0.0",
@@ -11116,17 +11039,17 @@
       }
     },
     "gatsby-graphiql-explorer": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.8.0.tgz",
-      "integrity": "sha512-D8ufRRaowRt0qJ9gGyBrcv9+dEvpaFJ3aLiEd8AWgHytROPHBp/M/2WDSd/0NSfK5p25i/9HhAccjcqnnCwiKQ==",
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.4.15.tgz",
+      "integrity": "sha512-Mo6wo6EX3pIL7ErKI0yJIfJw9iYDZyPyEsCQJDhcxymhqf1x0d8DRGDjyJDndDBiSuSUfgdBrHz/MKh3ZOZnAg==",
       "requires": {
-        "@babel/runtime": "^7.12.5"
+        "@babel/runtime": "^7.11.2"
       }
     },
     "gatsby-legacy-polyfills": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-legacy-polyfills/-/gatsby-legacy-polyfills-0.4.0.tgz",
-      "integrity": "sha512-Mj3S9fGJYesEissA5Y9P5AHGduWBeel4KPrhXYQ3htPPb+zkhXhk6q2JL+Eee33y31wOi9gEOrqWtJB2qW8QGA==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/gatsby-legacy-polyfills/-/gatsby-legacy-polyfills-0.0.6.tgz",
+      "integrity": "sha512-23O0orFhu1zkCluIFBs8pu8psfyyWquczfRk2NNdT2x4wW/HkZEjonWM5AkM6kjzZL9JrVCAZEgL4qf9OjgUoA==",
       "requires": {
         "core-js-compat": "^3.6.5"
       }
@@ -11948,9 +11871,9 @@
       }
     },
     "gatsby-plugin-utils": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-utils/-/gatsby-plugin-utils-0.6.0.tgz",
-      "integrity": "sha512-xoniyZtU1NLQJtb1JQaGQOjt7rriJcklfSaUnWfWojg0HmOxs+tm1ImpfHL9AOhNkVGim/YbQFXZqOQj/oUM+Q==",
+      "version": "0.2.40",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-utils/-/gatsby-plugin-utils-0.2.40.tgz",
+      "integrity": "sha512-RKjmpPhmi8TDR9hAKxmD4ZJMje3BLs6nt6mxMWT0F8gf5giCYEywplJikyCvaPfuyaFlq1hMmFaVvzmeZNussg==",
       "requires": {
         "joi": "^17.2.1"
       }
@@ -12087,9 +12010,9 @@
           }
         },
         "@graphql-tools/utils": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.0.tgz",
-          "integrity": "sha512-dVQHhuh/W6KlmSOQZliHH7ba41dsCOhqPwkeW6dwOjy0FqSx/hGihKZyABDmjNkDbowr2141aAIJYfj2XdoX8Q==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.3.tgz",
+          "integrity": "sha512-9MvSKeo+8DM72706FvrUP8figQjRzSwBswWrXviyWyt3wSkk6MU2cURQKfMpc0I6nswZvkDSqYoQQ/6mazoXxA==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -13163,9 +13086,9 @@
       }
     },
     "http-parser-js": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.2.tgz",
-      "integrity": "sha512-opCO9ASqg5Wy2FNo7A0sxy71yGbbkJJXLdgMK04Tcypw9jr2MgWbyubb0+WdmDmGnFflO7fRbqbaihh/ENDlRQ=="
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
+      "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg=="
     },
     "http-proxy": {
       "version": "1.18.1",
@@ -14676,6 +14599,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/lock/-/lock-1.1.0.tgz",
       "integrity": "sha1-UxV0mdFlOxNspmRRBx/KYVcD+lU="
+    },
+    "lockfile": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+      "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
+      "requires": {
+        "signal-exit": "^3.0.2"
+      }
     },
     "lodash": {
       "version": "4.17.19",
@@ -18483,9 +18414,9 @@
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
     "query-string": {
-      "version": "6.13.7",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.7.tgz",
-      "integrity": "sha512-CsGs8ZYb39zu0WLkeOhe0NMePqgYdAuCqxOYKDR5LVCytDZYMGx3Bb+xypvQvPHVPijRXB0HZNFllCzHRe4gEA==",
+      "version": "6.13.8",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.8.tgz",
+      "integrity": "sha512-jxJzQI2edQPE/NPUOusNjO/ZOGqr1o2OBa/3M00fU76FsLXDVbJDv/p7ng5OdQyorKrkRz1oqfwmbe5MAMePQg==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "split-on-first": "^1.0.0",
@@ -18785,6 +18716,11 @@
             "mimic-fn": "^1.0.0"
           }
         },
+        "react-error-overlay": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-3.0.0.tgz",
+          "integrity": "sha512-XzgvowFrwDo6TWcpJ/WTiarb9UI6lhA4PMzS7n1joK3sHfBBBOQHUc0U4u57D6DWO9vHv6lVSWx2Q/Ymfyv4hw=="
+        },
         "restore-cursor": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -18825,9 +18761,9 @@
       }
     },
     "react-error-overlay": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-3.0.0.tgz",
-      "integrity": "sha512-XzgvowFrwDo6TWcpJ/WTiarb9UI6lhA4PMzS7n1joK3sHfBBBOQHUc0U4u57D6DWO9vHv6lVSWx2Q/Ymfyv4hw=="
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.8.tgz",
+      "integrity": "sha512-HvPuUQnLp5H7TouGq3kzBeioJmXms1wHy9EGjz2OURWBp4qZO6AfGEcnxts1D/CbwPLRAgTMPCEgYhA3sEM4vw=="
     },
     "react-helmet": {
       "version": "6.1.0",
@@ -19428,13 +19364,13 @@
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "renderkid": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.4.tgz",
-      "integrity": "sha512-K2eXrSOJdq+HuKzlcjOlGoOarUu5SDguDEhE7+Ah4zuOWL40j8A/oHvLlLob9PSTNvVnBd+/q0Er1QfpEuem5g==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.5.tgz",
+      "integrity": "sha512-ccqoLg+HLOHq1vdfYNm4TBeaCDIi1FLt3wGojTDSvdewUv65oTmI3cnT2E4hRjl1gzKZIPK+KZrXzlUYKnR+vQ==",
       "requires": {
-        "css-select": "^1.1.0",
+        "css-select": "^2.0.2",
         "dom-converter": "^0.2",
-        "htmlparser2": "^3.3.0",
+        "htmlparser2": "^3.10.1",
         "lodash": "^4.17.20",
         "strip-ansi": "^3.0.0"
       },
@@ -20176,13 +20112,6 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        }
       }
     },
     "slugify": {
@@ -20435,31 +20364,13 @@
       }
     },
     "sockjs": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.20.tgz",
-      "integrity": "sha512-SpmVOVpdq0DJc0qArhF3E5xsxvaiqGNb73XfgBpK1y3UD5gs8DSo8aCTsuT5pX8rssdc2NDIzANwP9eCAiSdTA==",
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.21.tgz",
+      "integrity": "sha512-DhbPFGpxjc6Z3I+uX07Id5ZO2XwYsWOrYjaSeieES78cq+JaJvVe5q/m1uvjIQhXinhIeCFRH6JgXe+mvVMyXw==",
       "requires": {
-        "faye-websocket": "^0.10.0",
+        "faye-websocket": "^0.11.3",
         "uuid": "^3.4.0",
-        "websocket-driver": "0.6.5"
-      },
-      "dependencies": {
-        "faye-websocket": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-          "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-          "requires": {
-            "websocket-driver": ">=0.5.1"
-          }
-        },
-        "websocket-driver": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
-          "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
-          "requires": {
-            "websocket-extensions": ">=0.1.1"
-          }
-        }
+        "websocket-driver": "^0.7.4"
       }
     },
     "sockjs-client": {
@@ -21383,30 +21294,6 @@
         "has-flag": "^3.0.0"
       }
     },
-    "supports-hyperlinks": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
-      "integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
-      "requires": {
-        "has-flag": "^4.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "svgo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
@@ -21491,9 +21378,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -21510,11 +21397,6 @@
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "3.1.0",
@@ -21820,30 +21702,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
       "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="
-    },
-    "terminal-link": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
-      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
-      "requires": {
-        "ansi-escapes": "^4.2.1",
-        "supports-hyperlinks": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-          "requires": {
-            "type-fest": "^0.11.0"
-          }
-        },
-        "type-fest": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
-        }
-      }
     },
     "terser": {
       "version": "4.8.0",
@@ -23097,9 +22955,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.0.tgz",
-      "integrity": "sha512-PUxZ+oSTxogFQgkTtFndEtJIPNmml7ExwufBZ9L2/Xyyd5PnOL5UreWe5ZT7IU25DSdykL9p1MLQzmLh2ljSeg==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.1.tgz",
+      "integrity": "sha512-u4R3mRzZkbxQVa+MBWi2uVpB5W59H3ekZAJsQlKUTdl7Elcah2EhygTPLmeFXybQkf9i2+L0kn7ik9SnXa6ihQ==",
       "requires": {
         "ansi-html": "0.0.7",
         "bonjour": "^3.5.0",
@@ -23121,11 +22979,11 @@
         "p-retry": "^3.0.1",
         "portfinder": "^1.0.26",
         "schema-utils": "^1.0.0",
-        "selfsigned": "^1.10.7",
+        "selfsigned": "^1.10.8",
         "semver": "^6.3.0",
         "serve-index": "^1.9.1",
-        "sockjs": "0.3.20",
-        "sockjs-client": "1.4.0",
+        "sockjs": "^0.3.21",
+        "sockjs-client": "^1.5.0",
         "spdy": "^4.0.2",
         "strip-ansi": "^3.0.1",
         "supports-color": "^6.1.0",
@@ -23319,16 +23177,16 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "sockjs-client": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.4.0.tgz",
-          "integrity": "sha512-5zaLyO8/nri5cua0VtOrFXBPK1jbL4+1cebT/mmKA1E1ZXOvJrII75bPu0l0k843G/+iAbhEqzyKr0w/eCCj7g==",
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.0.tgz",
+          "integrity": "sha512-8Dt3BDi4FYNrCFGTL/HtwVzkARrENdwOUf1ZoW/9p3M8lZdFT35jVdrHza+qgxuG9H3/shR4cuX/X9umUrjP8Q==",
           "requires": {
-            "debug": "^3.2.5",
+            "debug": "^3.2.6",
             "eventsource": "^1.0.7",
-            "faye-websocket": "~0.11.1",
-            "inherits": "^2.0.3",
-            "json3": "^3.3.2",
-            "url-parse": "^1.4.3"
+            "faye-websocket": "^0.11.3",
+            "inherits": "^2.0.4",
+            "json3": "^3.3.3",
+            "url-parse": "^1.4.7"
           },
           "dependencies": {
             "debug": {
@@ -23338,6 +23196,11 @@
               "requires": {
                 "ms": "^2.1.1"
               }
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
             }
           }
         },
@@ -23880,9 +23743,9 @@
       }
     },
     "xstate": {
-      "version": "4.15.2",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.15.2.tgz",
-      "integrity": "sha512-C+3jzJbhkp9ywGB+E2YMbS4mLyuxv366+KGi2RBX6y99xZFezbrGfaPQGRvFvn58OlLlCuSfCwn6bPcp78aMyw=="
+      "version": "4.15.3",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.15.3.tgz",
+      "integrity": "sha512-nf4zzLNs5W57stMZib9UG9PA5ywu89INsaXBMZf7iQxkYD9apbIOQcK8nu/iVZEDOVE+vR8GQnTaOg/8iDSK5Q=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "5.0.0",
   "author": "Taylor Bryant <taylor@bryant.io>",
   "dependencies": {
-    "gatsby": "2.29.2",
+    "gatsby": "^2.25.1",
     "gatsby-plugin-manifest": "2.8.0",
     "gatsby-plugin-offline": "3.7.1",
     "gatsby-plugin-postcss": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "5.0.0",
   "author": "Taylor Bryant <taylor@bryant.io>",
   "dependencies": {
-    "gatsby": "^2.25.1",
+    "gatsby": "2.25.1",
     "gatsby-plugin-manifest": "2.8.0",
     "gatsby-plugin-offline": "3.7.1",
     "gatsby-plugin-postcss": "3.3.0",


### PR DESCRIPTION
Newer releases of Gatsby have a bug that causes a flash of unstyled content (see https://github.com/gatsbyjs/gatsby/issues/28805#issuecomment-753239651).

This PR rolls back to an older known working version.